### PR TITLE
Update xts.R so it uses "frequency" argument

### DIFF
--- a/R/xts.R
+++ b/R/xts.R
@@ -93,6 +93,7 @@ function(x=NULL,
             tclass=orderBy,
             .indexTZ=tzone,
             tzone=tzone,
+            frequency=frequency,
             ...)
   if(!is.null(attributes(x)$dimnames[[1]]))
     # this is very slow if user adds rownames, but maybe that is deserved :)


### PR DESCRIPTION
frequency argument of **xts** function isn't used at the moment.

applying an intuitive fix by hand:

```
frequency(xts_object) <- new_value
```

unfortunately changed xts_object's class from c("xts", "zoo") to c("zooreg", "zoo")
